### PR TITLE
FixedJudgingMethodOfMountingStatus

### DIFF
--- a/SHARE_TARGET_DIR_LIST
+++ b/SHARE_TARGET_DIR_LIST
@@ -1,1 +1,1 @@
-share_nas
+share_media

--- a/backup2nas_v2.sh
+++ b/backup2nas_v2.sh
@@ -43,13 +43,13 @@ for ip_address in `seq 200 254`;do
   fi
 done
 
-# monunt to target
-result = 0
-touch ${DIR_HOME}/${DIR_TARGET_ROUTE} || result = $?
-if [ ${result} -ne 0 ]; then
+### monunt to target
+mount_status=`mount -v | grep ${DIR_MOUNT} | wc -l`
+if [ ${mount_status} < 1 ]; then
   echo "mount -t smbfs -w //${nas_user}:${nas_password}@${NAS_IP}/${NAS_DIR_MOUNTED} ${DIR_HOME}/${DIR_MOUNT} || exit 1"
   mount -t smbfs -w //${nas_user}:${nas_password}@${NAS_IP}/${NAS_DIR_MOUNTED} ${DIR_HOME}/${DIR_MOUNT} || exit 1   ### Mount to nas.
 fi
+
 
 ## Sync directories
 while read DIR_TARGET_BRANCH

--- a/share2nas.sh
+++ b/share2nas.sh
@@ -42,8 +42,8 @@ for ip_address in `seq 200 254`;do
 done
 
 ### monunt to target
-mount_status=`mount -v | grep ${DIR_MOUNT} | wc -l`
-if [ ${mount_status} < 1 ]; then
+mount_status=`mount -v | grep ${DIR_MOUNT} | wc -l | sed -e 's/ //g'`
+if [ ${mount_status} -lt 1 ]; then
   mount -t smbfs -w //${nas_user}:${nas_password}@${NAS_IP}/${NAS_DIR_MOUNTED} ${DIR_HOME}/${DIR_MOUNT} || exit 1   ### Mount to nas.
   echo `mount -v`
 fi
@@ -51,7 +51,10 @@ fi
 ## Sync directories
 while read DIR_TARGET_BRANCH
 do
-  echo "rsync -ahvru ${DIR_HOME}/${DIR_TARGET_ROOT}/${DIR_TARGET_BRANCH} ${DIR_HOME}/${DIR_DST}/${DIR_TARGET_BRANCH} > ${SCRIPT_DIR}/log/rsync_${DIR_TARGET_ROOT}.log &"
-  rsync -ahvru ${DIR_HOME}/${DIR_TARGET_ROOT}/${DIR_TARGET_BRANCH} ${DIR_HOME}/${DIR_DST}/ > ${SCRIPT_DIR}/log/rsync_${DIR_TARGET_ROOT}.log &  ### Sync data.
-  wait $!
+  mount_status=`mount -v | grep ${DIR_MOUNT} | wc -l | sed -e 's/ //g'`
+  if [ ${mount_status} -ge 1 ]; then
+    echo "rsync -ahvru ${DIR_HOME}/${DIR_TARGET_ROOT}/${DIR_TARGET_BRANCH} ${DIR_HOME}/${DIR_DST}/${DIR_TARGET_BRANCH} > ${SCRIPT_DIR}/log/rsync_${DIR_TARGET_ROOT}.log &"
+    rsync -ahvru ${DIR_HOME}/${DIR_TARGET_ROOT}/${DIR_TARGET_BRANCH} ${DIR_HOME}/${DIR_DST}/ > ${SCRIPT_DIR}/log/rsync_${DIR_TARGET_ROOT}.log &  ### Sync data.
+    wait $!
+  fi
 done < $SHARE_LIST

--- a/share2nas.sh
+++ b/share2nas.sh
@@ -41,11 +41,11 @@ for ip_address in `seq 200 254`;do
   fi
 done
 
-# monunt to target
-result = 0
-touch ${DIR_HOME}/${DIR_TARGET_ROUTE} || result = $?
-if [ ${result} -ne 0 ]; then
+### monunt to target
+mount_status=`mount -v | grep ${DIR_MOUNT} | wc -l`
+if [ ${mount_status} < 1 ]; then
   mount -t smbfs -w //${nas_user}:${nas_password}@${NAS_IP}/${NAS_DIR_MOUNTED} ${DIR_HOME}/${DIR_MOUNT} || exit 1   ### Mount to nas.
+  echo `mount -v`
 fi
 
 ## Sync directories


### PR DESCRIPTION
# what
Changed the method of determining the mount status on the NAS.
Before change: Access to the NAS directory is successful.
After change: The number of mounts on the NAS must be 1 or more.
# why
This is because the local directory is judged as the NAS when the NAS is not mounted.